### PR TITLE
:cow: Configuration for single service stack rancher deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,4 @@ script:
   - ./test/tests
 
 after_success:
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - ./scripts/ci-deployment/docker_ci.sh
+  - bash ./scripts/ci-deployment/deploy.sh

--- a/rancher-config/docker-compose.yml
+++ b/rancher-config/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+
+services:
+
+  profiles-db-elastic:
+    image: "nhsuk/profiles-db-elastic:${DOCKER_IMAGE_TAG}"
+    labels:
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.affinity:host_label_soft: c2s=true

--- a/rancher-config/rancher-compose.yml
+++ b/rancher-config/rancher-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+
+services:
+
+  profiles-db-elastic:
+    scale: 1
+    start_on_create: true
+    health_check:
+      response_timeout: 60000
+      healthy_threshold: 2
+      port: 9200
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 20000
+      strategy: recreate
+      request_line: ''
+      reinitializing_timeout: 60000


### PR DESCRIPTION
In order for this to work in the integration environment the following change needed to be made. Set `ES_HOST` to `<rancher_stack_name>.<rancher_stack_name>-pr<number>` e.g. `profiles-db-elastic.profiles-db-elastic-pr-15`