### PR TITLE
:no_entry: Extend GP specific stop words

### DIFF
--- a/data/mapping/mapping.json
+++ b/data/mapping/mapping.json
@@ -14,7 +14,21 @@
       "filter":{
         "gp_stop":{
           "type":"stop",
-          "stopwords": ["doctor", "doctors", "dr", "drs" ]
+          "stopwords": [ 
+            "and",
+            "the",
+            "&",
+            "doctor",
+            "doctors",
+            "dr",
+            "drs",
+            "partners",
+            "practice",
+            "surgery",
+            "medical",
+            "health",
+            "centre",
+            "center" ]
         }
       }
     }


### PR DESCRIPTION
Extend the stop words to include all medical specific ones which have more than 1000 occurences in the GP address/name data. The common connective words also added to the list.

The stop word frequencies and `jq` commands to generate them are documented below. More background in the Trello card [here](https://trello.com/c/gpdiuh7f/233-search-for-a-gp-surgery-by-doctor-s-name).