### PR TITLE
:up: Upgrade to ES 5.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM elasticsearch:5.3.0
+FROM elasticsearch:5.4.0
 RUN apt-get update && apt-get install -y \
     jq
 


### PR DESCRIPTION
Upgrade to Elasticsearch
[5.4.0](https://www.elastic.co/blog/elasticsearch-5-4-0-released)
Latest version of kibana is supported.

Version 5.4.1 has not been upgraded to due to there not being a version
of that image hosted on
[dockerhub](https://hub.docker.com/_/elasticsearch/)