### PR TITLE
Do not index large properties

### DIFF
--- a/data/mapping/mapping.json
+++ b/data/mapping/mapping.json
@@ -25,6 +25,21 @@
   "mappings": {
     "gps": {
       "properties": {
+        "openingTimes": {
+          "enabled": false
+        },
+        "facilities": {
+          "enabled": false
+        },
+        "services": {
+          "enabled": false
+        },
+        "onlineServices": {
+          "enabled": false
+        },
+        "contact": {
+          "enabled": false
+        },
         "acceptingNewPatients": {
           "type": "boolean"
         },
@@ -76,15 +91,6 @@
           }
         },
         "name": {
-          "type": "text",
-          "fields": {
-            "keyword": {
-              "type": "keyword",
-              "ignore_above": 256
-            }
-          }
-        },
-        "addressLine0": {
           "type": "text",
           "fields": {
             "keyword": {

--- a/data/scripts/transform-data-filter.jq
+++ b/data/scripts/transform-data-filter.jq
@@ -3,5 +3,4 @@
 .alternativeName = .address.addressLines[0] |
 .id = ._id |
 del (._id) |
-del (.openingTimes) |
 {"index": {"_index": "profiles", "_type": "gps", "_id": .id}}, .


### PR DESCRIPTION
This was prompted by a desire to do as little preprocessing as possible. Without preprocessing to remove `openingTimes` or disabling indexing on it ES throws an error due to too the max number of indexable fields being exceeded.

The other `disable`s follow on from that. There are other smaller properties which could also be disabled but this is a start in keeping the indexing fast and small.

Any retrieved documents will still have the disabled fields - they are just not included in indexing.